### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,8 +6,8 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-irmp_protocol_names KEYWORD1
-IRMP_DATA   KEYWORD1
+irmp_protocol_names	KEYWORD1
+IRMP_DATA	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
@@ -17,15 +17,15 @@ irmp_init	KEYWORD2
 irmp_get_data	KEYWORD2
 irmp_ISR	KEYWORD2
 irmp_register_complete_callback_function	KEYWORD2
-irmp_blink13    KEYWORD2
-irmp_init_timer2    KEYWORD2
+irmp_blink13	KEYWORD2
+irmp_init_timer2	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
 IRMP_FLAG_REPETITION	LITERAL1
-IRMP_PROTOCOL_NAMES LITERAL1
-IRMP_USE_COMPLETE_CALLBACK  LITERAL1
-F_INTERRUPTS    LITERAL1
-IRMP_ENABLE_PIN_CHANGE_INTERRUPT    LITERAL1
+IRMP_PROTOCOL_NAMES	LITERAL1
+IRMP_USE_COMPLETE_CALLBACK	LITERAL1
+F_INTERRUPTS	LITERAL1
+IRMP_ENABLE_PIN_CHANGE_INTERRUPT	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords