### PR TITLE
Added struct name to allow for forward declaration.

### DIFF
--- a/src/irmpsystem.h
+++ b/src/irmpsystem.h
@@ -226,7 +226,7 @@ typedef unsigned short                  uint_fast16_t;
 
 #if IRMP_32_BIT == 1
 
-typedef struct
+typedef struct IRMP_PACKED_STRUCT
 {
     uint8_t                             protocol;                                   // protocol, e.g. NEC_PROTOCOL
     uint16_t                            address;                                    // address


### PR DESCRIPTION
I was prevented from doing a forward declaration of IRMP_DATA in my .h file because it didn't have a name unlike the non 32 bit version. So just added the name to allow me to do a forward declaration in my .h file.