### PR TITLE
Removed no longer needed lines for Apollo 3

### DIFF
--- a/src/IRTimer.cpp.h
+++ b/src/IRTimer.cpp.h
@@ -653,20 +653,6 @@ void enableIRTimerInterrupt(void)
  * We use TIMER2_COMPB_vect to be compatible with tone() library
  */
 
-//#if defined(ARDUINO_ARCH_APOLLO3)
-///*
-// * The isr, which calls the dispatcher/service, which call the irmp_timer_ISR
-// */
-//extern "C" void am_ctimer_isr(void) {
-//    // Check and clear any active CTIMER interrupts.
-//    uint32_t ui32Status = am_hal_ctimer_int_status_get(true);
-//    am_hal_ctimer_int_clear(ui32Status);
-//
-//    // Run handlers for the various possible timer events.
-//    am_hal_ctimer_int_service(ui32Status);
-//}
-//#endif
-
 #if defined(__AVR__)
 
 #  if F_CPU < 8000000L

--- a/src/irmpArduinoExt.h
+++ b/src/irmpArduinoExt.h
@@ -80,10 +80,6 @@
 
 #elif defined(ARDUINO_ARCH_MBED) // Arduino Nano 33 BLE + Sparkfun Apollo3
 #include "mbed.h"
-// F is undefined in mbed.h, so F() is unknown and leads to "'F' was not declared in this scope" errors. -> define it again.
-#ifndef F
-#define F(a) a
-#endif
 
 #elif defined(ESP32)
 #elif defined(STM32F1xx) // for "Generic STM32F1 series" from "STM32 Boards (selected from submenu)" of Arduino Board manager

--- a/src/irsndArduinoExt.h
+++ b/src/irsndArduinoExt.h
@@ -60,10 +60,6 @@ void irsnd_data_print(Print *aSerial, IRMP_DATA *aIRMPDataPtr);
 
 #if defined(ARDUINO_ARCH_MBED) // Arduino Nano 33 BLE + Sparkfun Apollo3
 #include "mbed.h"
-// F is undefined in mbed.h, so F() is unknown and leads to "'F' was not declared in this scope" errors. -> define it again.
-#ifndef F
-#define F(a) a
-#endif
 #define F_CPU 0 // dummy definition to avoid warning at irsnd.c.h:27 #error F_CPU unkown
 #endif
 


### PR DESCRIPTION
This fixes #34. I have run both simpleSend and simpleReceive to verify that it works properly on a board that uses the Sparkfun Apollo3 as its core. 