### PR TITLE
Add mbed_nano to list of compatible architectures

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=Receive and send infrared signals.<br/>
 paragraph=<ul><li>Supports <b>50 different IR and 3 RF protocols</b>.</li><li>Can receive <b>40 protocols concurrently</b>.</li><li><b>Small</b> footprint and <b>robust</b> decoding.</li><li>Receive and send can be used in the <b>same sketch.</b></li><li>Supports ATtiny, AVR and MegaAVR boards as well as ESP8266, ESP32, STM32, SAMD and Apollo boards.</li></ul><br/>For a short comparison of 4 popular IR libraries, see <a href="https://github.com/ukw100/IRMP#quick-comparison-of-4-arduino-ir-receiving-libraries">GitHub README</a><br/><br/><b>New: </b>Added ATtiny3217 / TinyCore support and fixed a few timings. Added Melinera protocol and single repeat for NEC.<br/>
 category=Signal Input/Output
 url=https://github.com/ukw100/IRMP
-architectures=avr,megaavr,samd,esp8266,esp32,stm32,STM32F1,apollo3,mbed
+architectures=avr,megaavr,samd,esp8266,esp32,stm32,STM32F1,apollo3,mbed,mbed_nano
 includes=Arduino.h


### PR DESCRIPTION
In the 2.0.0 release of the Arduino Mbed OS Boards platform, the mbed architecture split into four architectures:

- mbed_edge: Arduino Edge Control
- mbed_nano: Nano 33 BLE and Nano RP2040 Connect
- mbed_rp2040: Raspberry Pi Pico
- mbed_portenta: Portenta H7

The mbed architecture should be retained for backwards support, but the new mbed_nano should also be added to avoid spurious incompatibility warnings and the library's examples being shown under the File > Examples > INCOMPATIBLE menu of the Arduino IDE when the Nano 33 BLE board is selected.