### PR TITLE
Fix Timer1 initialization for ATtinyX7 parts

### DIFF
--- a/src/IRTimer.cpp.h
+++ b/src/IRTimer.cpp.h
@@ -135,7 +135,7 @@ void initIRTimerForSend(void)
 #  elif defined(__AVR_ATtiny87__) || defined(__AVR_ATtiny167__)
 // Timer 1 is a 16 bit counter so we need no prescaler
     ICR1 = (F_CPU / IR_INTERRUPT_FREQUENCY) - 1;                    // 1065 for 15 kHz @16 MHz. compare value: 1/15000 of CPU frequency
-    TCCR1B = 0;                                                     // switch CTC Mode on
+    TCCR1A = 0;                                                     // switch CTC Mode on
     TCCR1B = _BV(WGM12) | _BV(WGM13) | _BV(CS10);                   // switch CTC Mode on, set prescaler to 1 / no prescaling
     TCNT1 = 0;
     TIMSK1 = _BV(OCIE1B);                                           // enable compare match interrupt


### PR DESCRIPTION
Not an issue with the Digispark core, since it sets TCCR1A to 0 by default.  However, the ATTinyCore uses different settings, so not updating TCCR1A means that Timer1 is not in the desired mode.